### PR TITLE
Add custom.conf

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM java:8
 
-ADD https://s3-eu-west-1.amazonaws.com/softwaremill-public/elasticmq-server-0.12.0.jar /
-ENTRYPOINT ["/usr/bin/java", "-jar", "/elasticmq-server-0.12.0.jar"]
+ADD https://s3-eu-west-1.amazonaws.com/softwaremill-public/elasticmq-server-0.13.1.jar /
+COPY custom.conf /
+ENTRYPOINT ["/usr/bin/java", "-Dconfig.file=custom.conf", "-jar", "/elasticmq-server-0.13.1.jar"]
 
 EXPOSE 9324
 

--- a/custom.conf
+++ b/custom.conf
@@ -1,0 +1,8 @@
+include classpath("application.conf")
+
+node-address {
+    protocol = http
+    host = "*"
+    port = 9324
+    context-path = ""
+}


### PR DESCRIPTION
This makes the host addressable under its assigned IP.
Now works with docker-machine which runs your containers on
a VM with a designated IP address (i.e. not localhost).

See https://github.com/adamw/elasticmq#how-are-queue-urls-created

I'm not running docker native so can't check that it
still works using 'localhost' after this change.

Also updated ElasticMQ version to 0.13.1.