### PR TITLE
update elasticmq version to use fifo queue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM java:8
 
-ADD https://s3-eu-west-1.amazonaws.com/softwaremill-public/elasticmq-server-0.13.8.jar /
+ADD https://s3-eu-west-1.amazonaws.com/softwaremill-public/elasticmq-server-0.14.4.jar /
 COPY custom.conf /
-ENTRYPOINT ["/usr/bin/java", "-Dconfig.file=custom.conf", "-jar", "/elasticmq-server-0.13.8.jar"]
+ENTRYPOINT ["/usr/bin/java", "-Dconfig.file=custom.conf", "-jar", "/elasticmq-server-0.14.4.jar"]
 
 EXPOSE 9324
 


### PR DESCRIPTION
I'd like to use FIFO queue with docker-SQS-local. Thanks.