### PR TITLE
Update ElasticMQ 1.5.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM openjdk:8-alpine
 
-ADD https://s3-eu-west-1.amazonaws.com/softwaremill-public/elasticmq-server-1.3.9.jar /
+ADD https://s3-eu-west-1.amazonaws.com/softwaremill-public/elasticmq-server-1.5.7.jar /
 COPY custom.conf /
-ENTRYPOINT ["/usr/bin/java", "-Dconfig.file=custom.conf", "-jar", "/elasticmq-server-1.3.9.jar"]
+ENTRYPOINT ["/usr/bin/java", "-Dconfig.file=custom.conf", "-jar", "/elasticmq-server-1.5.7.jar"]
 
 EXPOSE 9324
 


### PR DESCRIPTION
Due to the change in the AWS SDK request format from XML to JSON, errors occur with specific versions of the AWS SDK.
This pull request has been created to address the issue by upgrading the version of Elastic MQ.

For more details, please refer to the following link:
https://github.com/aws/aws-sdk-js/issues/4523

If there are any necessary steps before merging, please let me know.